### PR TITLE
Treat application/xhtml+xml as HTML

### DIFF
--- a/lib/rack/livereload/processing_skip_analyzer.rb
+++ b/lib/rack/livereload/processing_skip_analyzer.rb
@@ -37,7 +37,7 @@ module Rack
       end
 
       def html?
-        @headers['Content-Type'] =~ %r{text/html}
+        @headers['Content-Type'] =~ %r{text/html|application/xhtml\+xml}
       end
 
       def get?

--- a/spec/rack/livereload/processing_skip_analyzer_spec.rb
+++ b/spec/rack/livereload/processing_skip_analyzer_spec.rb
@@ -95,6 +95,12 @@ describe Rack::LiveReload::ProcessingSkipAnalyzer do
       it { should be_html }
     end
 
+    context 'XHTML content' do
+      let(:headers) { { 'Content-Type' => 'application/xhtml+xml' } }
+
+      it { should be_html }
+    end
+
     context 'PDF content' do
       let(:headers) { { 'Content-Type' => 'application/pdf' } }
 


### PR DESCRIPTION
This makes _rack-livereload_ work with XHTML as well. 

This fixes nanoc/nanoc#1473.